### PR TITLE
Remove custom_theme dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "drupal/bootstrap": "^3.23",
+        "drupal/gin": "^3.0",
         "drupal/core": "^8",
         "os2forms/os2forms": "^2.6",
         "os2forms/os2forms_forloeb": "^1.3",

--- a/os2forms_forloeb_profile.info.yml
+++ b/os2forms_forloeb_profile.info.yml
@@ -119,5 +119,3 @@ install:
 themes:
   - gin
   - claro
-  - bootstrap
-  - custom_theme

--- a/os2forms_forloeb_profile.install
+++ b/os2forms_forloeb_profile.install
@@ -23,6 +23,24 @@ function os2forms_forloeb_profile_install() {
   // We install some menu links, so we have to rebuild the router, to ensure the
   // menu links are valid.
   \Drupal::service('router.builder')->rebuildIfNeeded();
+
+  // set Gin as default theme
+  $theme_list = [
+    'claro',
+    'gin'
+  ];
+
+  // Install themes
+  \Drupal::service('theme_installer')->install($theme_list);
+
+  // Get theme manager
+  $system_theme = \Drupal::configFactory()->getEditable('system.theme');
+
+  // Set default and admin themes
+  $system_theme
+    ->set('default', 'gin')
+    ->set('admin', 'gin')
+    ->save();
 }
 
 /**


### PR DESCRIPTION
What it says on the tin. Removes `custom_theme` dependency so that the profile can be used in projects that don't have that theme.