### PR TITLE
feature/os2forms 2.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "drupal/gin": "^3.0",
         "drupal/core": "^8 || ^9",
-        "os2forms/os2forms": "^3.0",
+        "os2forms/os2forms": "^2.8",
         "os2forms/os2forms_forloeb": "^1.8",
         "os2web/os2web_simplesaml": "8.x-dev"
     },


### PR DESCRIPTION
`"os2forms/os2forms": "^3.0"` and `"os2forms/os2forms_forloeb": "^1.8"` conflict when running `composer install`.
