### PR TITLE
[#47448] Changed defaults for mail-system to SMTP

### DIFF
--- a/config/install/mailsystem.settings.yml
+++ b/config/install/mailsystem.settings.yml
@@ -1,0 +1,3 @@
+defaults:
+  sender: SMTPMailSystem
+  formatter: SMTPMailSystem


### PR DESCRIPTION
This sets the defaults in mail-system to the SMTP-modle.
This is needed since SMTP can attach files to emails.