### PR TITLE
Composer cleanup

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,4 +16,4 @@ jobs:
         run: git fetch
 
       - name: Check that changelog has been updated.
-        run: git diff --exit-code origin/develop -- CHANGELOG.md && exit 1 || exit 0
+        run: git diff --exit-code origin/${{ github.base_ref }} -- CHANGELOG.md && exit 1 || exit 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,19 @@
+on: pull_request
+name: Review
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    name: Changelog should be updated
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Git fetch
+        run: git fetch
+
+      - name: Check that changelog has been updated.
+        run: git diff --exit-code origin/develop -- CHANGELOG.md && exit 1 || exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ See ["how do I make a good changelog record?"](https://keepachangelog.com/en/1.0
 before starting to add changes.
 
 ## [Unreleased]
+- Added github action for checking changelog changes when creating pull requests
+- Updated readme
+- Removed webform_embed from repositories
+- Removed array keys from repositories list
+- Updated drupal core dependency
+- Updated gin dependency
+- Updated os2forms dependency
+- Updated os2forms_forloeb dependency
+- Added cweagans/composer-patches as dependency
+- Removed drupal/dynamic_entity_reference (It belongs in os2forms/os2forms_forloeb)
+- Changed composer patching configuration
 
 ### Added
 - Github CI action for checking Drupal Coding standards with PHP Code Sniffer

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ composer create-project --stability=dev drupal/recommended-project:^9.0 os2forms
 
 3) Require the development version of os2forms_forloeb_profile.
 ```
-yes | composer require os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
+yes | composer require "os2forms/os2forms:dev-composer_cleanup as 3.3.0" "os2forms/os2forms_forloeb:dev-composer_cleanup as 2.5.0" os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
 ```
 
 ### Install the os2forms_forloeb_profile

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ composer create-project --stability=dev drupal/recommended-project:^9.0 os2forms
 yes | composer require os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
 ```
 
+
+
+
+
 ### Setup your local settings file
 
 web/sites/default/settings.local.php

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OS2forms med Forløb installation profile for Drupal 8
+# OS2forms med Forløb installation profile for Drupal 9
 
-This is a Drupal 8 installation profile for OS2forms project.
+This is a Drupal 9 installation profile for OS2forms project.
 
 ## Create a new drupal 9 project
 ```

--- a/README.md
+++ b/README.md
@@ -2,14 +2,45 @@
 
 This is a Drupal 8 installation profile for OS2forms project.
 
-### Create a new drupal project
+## Create a new drupal 9 project
 ```
 composer create-project drupal/recommended-project:^9.0 os2forms
 ```
 
-### Require this Drupal install profile.
+### !!!NOTE Temporary installation of install profile
+@todo Update this after release of composer cleanup.
+
+1) Add our development sources to repositories list.
 ```
-composer require os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" -W
+"repositories": [
+...
+    {
+        "type": "vcs",
+        "url": "https://github.com/itk-dev/os2forms_forloeb_profile"
+    },
+    {
+        "type": "vcs",
+        "url": "https://github.com/itk-dev/os2forms_forloeb"
+    },
+    {
+        "type": "vcs",
+        "url": "https://github.com/itk-dev/os2forms"
+    }
+],
+```
+
+2) Use aliases to build project on our development sources.
+```
+"require": {
+...
+    "os2forms/os2forms": "dev-composer_cleanup as 3.3.0",
+    "os2forms/os2forms_forloeb": "dev-composer_cleanup as 2.5.0",
+},
+```
+
+3) Require the development version of os2forms_forloeb_profile.
+```
+composer require os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
 ```
 
 ### Setup your local settings file

--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ composer create-project --stability=dev drupal/recommended-project:^9.0 os2forms
 ```
 
 ### !!!NOTE Temporary installation of install profile
-@todo Update this after release of composer cleanup.
-  - Remove added repositories
-  - Remove aliases
-  - Update require command.
+
+--
+
+@todo Update this section after release of composer cleanup.
+- Remove added repositories
+- Remove aliases
+- Update require command.
+
+--
 
 1) Add our development sources to repositories list.
 ```
@@ -46,14 +51,10 @@ composer create-project --stability=dev drupal/recommended-project:^9.0 os2forms
 yes | composer require os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
 ```
 
-
-
-
-
-### Setup your local settings file
-
-web/sites/default/settings.local.php
-```
+### Set up your local settings file
+Create file: web/sites/default/settings.local.php
+```php
+<?php
 /**
  * Database connection.
  */
@@ -90,15 +91,7 @@ if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
 }
 ```
 
-### Require drush for your project
-```
-composer require drush/drush
-```
-
 ### Install site with this installation profile
 ```
 vendor/bin/drush -y site-install os2forms_forloeb_profile
 ```
-
-## Usage
-It's not supposed to use this profile outside https://github.com/os2forms/os2forms8 project.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Drupal 9 installation profile for OS2forms project.
 
 ## Create a new drupal 9 project with dev stability to allow all required packages to be installed.
 ```
-composer create-project --stability=dev drupal/recommended-project:^9.0 os2forms
+composer create-project drupal/recommended-project:^9.0 os2forms
 ```
 
 ### !!!NOTE Temporary installation of install profile
@@ -15,6 +15,7 @@ composer create-project --stability=dev drupal/recommended-project:^9.0 os2forms
 - Remove added repositories
 - Remove aliases
 - Update require command.
+- Remove "composer config minimum-stability dev"
 
 --
 
@@ -37,16 +38,17 @@ composer create-project --stability=dev drupal/recommended-project:^9.0 os2forms
 ],
 ```
 
-2) Add allowed plugins
+2) Change composer config
 ```
 composer config --no-plugins allow-plugins.zaporylie/composer-drupal-optimizations true
 composer config --no-plugins allow-plugins.cweagans/composer-patches true
 composer config --no-plugins allow-plugins.simplesamlphp/composer-module-installer true
+composer config minimum-stability dev
 ```
 
 3) Require the development version of os2forms_forloeb_profile and aliases of os2forms/os2forms_forloeb and os2forms/os2forms.
 ```
-yes | composer require "os2forms/os2forms:dev-composer_cleanup as 3.3.0" "os2forms/os2forms_forloeb:dev-composer_cleanup as 2.5.0" os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
+composer require "os2forms/os2forms:dev-composer_cleanup as 3.3.0" "os2forms/os2forms_forloeb:dev-composer_cleanup as 2.5.0" os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
 ```
 
 ### Install the os2forms_forloeb_profile

--- a/README.md
+++ b/README.md
@@ -2,5 +2,65 @@
 
 This is a Drupal 8 installation profile for OS2forms project.
 
+### Create a new drupal project
+```
+composer create-project drupal/recommended-project:^9.0 os2forms
+```
+
+### Require this Drupal install profile.
+```
+composer require os2forms/os2forms_forloeb_profile
+```
+
+### Setup your local settings file
+
+web/sites/default/settings.local.php
+```
+/**
+ * Database connection.
+ */
+$databases['default']['default'] = [
+  'database' => '',
+  'username' => '',
+  'password' => '',
+  'host' => '',
+  'port' => '',
+  'driver' => '',
+  'prefix' => '',
+];
+
+/**
+ * Config directory.
+ */
+$settings['config_sync_directory'] = '../config/sync';
+
+/**
+ * Hash salt.
+ */
+$settings['hash_salt'] = '';
+```
+
+### Setup settings.php
+```
+cp web/sites/default/default.settings.php web/sites/default/settings.php
+```
+
+Add local settings reference to web/sites/default/settings.php
+```
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+   include $app_root . '/' . $site_path . '/settings.local.php';
+}
+```
+
+### Require drush for your project
+```
+composer require drush/drush
+```
+
+### Install site with this installation profile
+```
+vendor/bin/drush -y site-install os2forms_forloeb_profile
+```
+
 ## Usage
 It's not supposed to use this profile outside https://github.com/os2forms/os2forms8 project.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ composer create-project drupal/recommended-project:^9.0 os2forms
 
 ### Require this Drupal install profile.
 ```
-composer require os2forms/os2forms_forloeb_profile
+composer require os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" -W
 ```
 
 ### Setup your local settings file

--- a/README.md
+++ b/README.md
@@ -37,16 +37,14 @@ composer create-project --stability=dev drupal/recommended-project:^9.0 os2forms
 ],
 ```
 
-2) Use aliases to build project on our development sources.
+2) Add allowed plugins
 ```
-"require": {
-...
-    "os2forms/os2forms": "dev-composer_cleanup as 3.3.0",
-    "os2forms/os2forms_forloeb": "dev-composer_cleanup as 2.5.0",
-},
+composer config --no-plugins allow-plugins.zaporylie/composer-drupal-optimizations true
+composer config --no-plugins allow-plugins.cweagans/composer-patches true
+composer config --no-plugins allow-plugins.simplesamlphp/composer-module-installer true
 ```
 
-3) Require the development version of os2forms_forloeb_profile.
+3) Require the development version of os2forms_forloeb_profile and aliases of os2forms/os2forms_forloeb and os2forms/os2forms.
 ```
 yes | composer require "os2forms/os2forms:dev-composer_cleanup as 3.3.0" "os2forms/os2forms_forloeb:dev-composer_cleanup as 2.5.0" os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
 ```

--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 This is a Drupal 9 installation profile for OS2forms project.
 
-## Create a new drupal 9 project
+## Create a new drupal 9 project with dev stability to allow all required packages to be installed.
 ```
-composer create-project drupal/recommended-project:^9.0 os2forms
+composer create-project --stability=dev drupal/recommended-project:^9.0 os2forms
 ```
 
 ### !!!NOTE Temporary installation of install profile
 @todo Update this after release of composer cleanup.
+  - Remove added repositories
+  - Remove aliases
+  - Update require command.
 
 1) Add our development sources to repositories list.
 ```
@@ -40,7 +43,7 @@ composer create-project drupal/recommended-project:^9.0 os2forms
 
 3) Require the development version of os2forms_forloeb_profile.
 ```
-composer require os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
+yes | composer require os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
 ```
 
 ### Setup your local settings file

--- a/README.md
+++ b/README.md
@@ -51,47 +51,5 @@ composer create-project --stability=dev drupal/recommended-project:^9.0 os2forms
 yes | composer require os2forms/os2forms_forloeb_profile:"dev-composer_cleanup" --with-all-dependencies
 ```
 
-### Set up your local settings file
-Create file: web/sites/default/settings.local.php
-```php
-<?php
-/**
- * Database connection.
- */
-$databases['default']['default'] = [
-  'database' => '',
-  'username' => '',
-  'password' => '',
-  'host' => '',
-  'port' => '',
-  'driver' => '',
-  'prefix' => '',
-];
-
-/**
- * Config directory.
- */
-$settings['config_sync_directory'] = '../config/sync';
-
-/**
- * Hash salt.
- */
-$settings['hash_salt'] = '';
-```
-
-### Setup settings.php
-```
-cp web/sites/default/default.settings.php web/sites/default/settings.php
-```
-
-Add local settings reference to web/sites/default/settings.php
-```
-if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
-   include $app_root . '/' . $site_path . '/settings.local.php';
-}
-```
-
-### Install site with this installation profile
-```
-vendor/bin/drush -y site-install os2forms_forloeb_profile
-```
+### Install the os2forms_forloeb_profile
+See https://www.drush.org/latest/commands/site_install

--- a/composer.json
+++ b/composer.json
@@ -6,19 +6,6 @@
     "prefer-stable": true,
     "license": "EUPL-1.2",
     "repositories": {
-        "webform_embed": {
-            "type": "package",
-            "package": {
-                "name": "drupal/webform_embed",
-                "type": "drupal-module",
-                "version": "1.x-dev",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://ftp.drupal.org/files/projects/webform_embed-8.x-1.x-dev.zip",
-                    "shasum": ""
-                }
-            }
-        },
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "drupal/gin": "^3.0-rc",
         "drupal/core": "^8 || ^9",
-        "os2forms/os2forms": "^3.4.0-dev",
-        "os2forms/os2forms_forloeb": "^2.6.0-dev",
+        "os2forms/os2forms": "^3.4",
+        "os2forms/os2forms_forloeb": "^2.6",
         "os2web/os2web_simplesaml": "8.x-dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6.5",
         "drupal/gin": "^3.0-rc",
-        "drupal/core": "^8 || ^9",
+        "drupal/core": "^9",
         "os2forms/os2forms": "^3.3",
         "os2forms/os2forms_forloeb": "^2.5",
         "os2web/os2web_simplesaml": "8.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "drupal/gin": "^3.0-rc",
         "drupal/core": "^8 || ^9",
-        "os2forms/os2forms": "^3.4",
-        "os2forms/os2forms_forloeb": "^2.6",
+        "os2forms/os2forms": "^3.3",
+        "os2forms/os2forms_forloeb": "^2.5",
         "os2web/os2web_simplesaml": "8.x-dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "drupal/gin": "^3.0",
+        "drupal/gin": "^3.0-rc",
         "drupal/core": "^8 || ^9",
         "os2forms/os2forms": "^3.1",
         "os2forms/os2forms_forloeb": "^2.0.0-rc",

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "drupal/gin": "^3.0-rc",
         "drupal/core": "^8 || ^9",
-        "os2forms/os2forms": "^3.4.0",
-        "os2forms/os2forms_forloeb": "^2.6.0",
+        "os2forms/os2forms": "^3.4.0-dev",
+        "os2forms/os2forms_forloeb": "^2.6.0-dev",
         "os2web/os2web_simplesaml": "8.x-dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "require": {
         "drupal/gin": "^3.0-rc",
         "drupal/core": "^8 || ^9",
-        "itk-dev/os2forms": "dev-composer_cleanup",
-        "itk-dev/os2forms_forloeb": "dev-composer_cleanup",
+        "os2forms/os2forms": "dev-composer_cleanup",
+        "os2forms/os2forms_forloeb": "dev-composer_cleanup",
         "os2web/os2web_simplesaml": "8.x-dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,21 +5,29 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "license": "EUPL-1.2",
-    "repositories": {
-        "drupal": {
+    "repositories": [
+        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         },
-        "assets": {
+        {
             "type": "composer",
             "url": "https://asset-packagist.org"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/itk-dev/os2forms"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/itk-dev/os2forms_forloeb"
         }
-    },
+    ],
     "require": {
         "drupal/gin": "^3.0-rc",
         "drupal/core": "^8 || ^9",
-        "os2forms/os2forms": "^3.1",
-        "os2forms/os2forms_forloeb": "^2.0.0-rc",
+        "itk-dev/os2forms": "dev-composer_cleanup",
+        "itk-dev/os2forms_forloeb": "dev-composer_cleanup",
         "os2web/os2web_simplesaml": "8.x-dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,21 +13,13 @@
         {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/itk-dev/os2forms"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/itk-dev/os2forms_forloeb"
         }
     ],
     "require": {
         "drupal/gin": "^3.0-rc",
         "drupal/core": "^8 || ^9",
-        "os2forms/os2forms": "dev-composer_cleanup",
-        "os2forms/os2forms_forloeb": "dev-composer_cleanup",
+        "os2forms/os2forms": "^3.1",
+        "os2forms/os2forms_forloeb": "^2.0.0-rc",
         "os2web/os2web_simplesaml": "8.x-dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         }
     ],
     "require": {
+        "cweagans/composer-patches": "^1.6.5",
         "drupal/gin": "^3.0-rc",
         "drupal/core": "^8 || ^9",
         "os2forms/os2forms": "^3.3",
@@ -28,18 +29,8 @@
     },
     "extra": {
         "composer-exit-on-patch-failure": true,
-        "patchLevel": {
-            "test": "-p2"
-        },
         "enable-patching": true,
-        "patcher": {
-            "force-reset": true
-        },
-        "patches": {
-            "drupal/dynamic_entity_reference": {
-                "entityQuery reference JOINs should specify target_type (https://www.drupal.org/project/dynamic_entity_reference/issues/3120952#comment-14141038)": "https://www.drupal.org/files/issues/2021-06-22/entityquery-reference-joins-should-specify-target_type-3120952-24.patch"
-            }
-        }
+        "patches": {}
     },
     "scripts": {
         "coding-standards-check/phpcs": [

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal/gin": "^3.0-rc",
         "drupal/core": "^9",
+        "drush/drush": "^11.4",
         "os2forms/os2forms": "^3.3",
         "os2forms/os2forms_forloeb": "^2.5",
         "os2web/os2web_simplesaml": "8.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "drupal/gin": "^3.0-rc",
         "drupal/core": "^8 || ^9",
-        "os2forms/os2forms": "^3.1",
-        "os2forms/os2forms_forloeb": "^2.0.0-rc",
+        "os2forms/os2forms": "^3.4",
+        "os2forms/os2forms_forloeb": "^2.6",
         "os2web/os2web_simplesaml": "8.x-dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,12 @@
         ]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "simplesamlphp/composer-module-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "cweagans/composer-patches": true,
+            "zaporylie/composer-drupal-optimizations": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "drupal/gin": "^3.0-rc",
         "drupal/core": "^8 || ^9",
-        "os2forms/os2forms": "^3.4",
-        "os2forms/os2forms_forloeb": "^2.6",
+        "os2forms/os2forms": "^3.4.0",
+        "os2forms/os2forms_forloeb": "^2.6.0",
         "os2web/os2web_simplesaml": "8.x-dev"
     },
     "require-dev": {


### PR DESCRIPTION
https://os2web.atlassian.net/browse/OS2FORMS-389

- Added github action for checking changelog changes when creating pull requests
- Updated readme
- Removed webform_embed from repositories
- Removed array keys from repositories list
- Updated drupal core dependency
- Updated gin dependency
- Updated os2forms dependency
- Updated os2forms_forloeb dependency
- Added cweagans/composer-patches as dependency
- Removed drupal/dynamic_entity_reference (It belongs in os2forms/os2forms_forloeb)
- Changed composer patching configuration

Relates to:
https://github.com/OS2Forms/os2forms/pull/36 and https://github.com/OS2Forms/os2forms_forloeb/pull/143