### PR TITLE
Remove simplesaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ before starting to add changes.
 
 ## [Unreleased]
 
+- Removed `simplesamlphp`
+
 ## [1.14.1] - 04.10.2023
 
 - coc_forms_auto_export dependency

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "drupal/core": "^9",
         "drush/drush": "^11.4",
         "os2forms/os2forms": "^3.6",
-        "os2web/os2web_simplesaml": "8.x-dev",
         "drupal/cache_control_override": "^1.1|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
### Not to be merged.

PR for removing SAML.

Used for generating patch (.diff) for use in our local installation.